### PR TITLE
Fix random generation for parallel Monte Carlo

### DIFF
--- a/src/main/java/jp/sobue/math/MonteCarloMethod.java
+++ b/src/main/java/jp/sobue/math/MonteCarloMethod.java
@@ -1,5 +1,6 @@
 package jp.sobue.math;
 
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.LongStream;
 
@@ -29,7 +30,9 @@ public class MonteCarloMethod {
         .parallel()
         .forEach(
             i -> {
-              if (isInsideCircle(Math.random(), Math.random())) {
+              double x = ThreadLocalRandom.current().nextDouble();
+              double y = ThreadLocalRandom.current().nextDouble();
+              if (isInsideCircle(x, y)) {
                 insideCircleCnt.incrementAndGet();
               } else {
                 outsideCircleCnt.incrementAndGet();


### PR DESCRIPTION
## Summary
- switch from `Math.random()` to `ThreadLocalRandom` to avoid contention when running the algorithm in parallel

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864056a4c8c8332878863e39ea0b3a5